### PR TITLE
[mac os x] ensures newly created window is drawn in front and active

### DIFF
--- a/darwin/window.m
+++ b/darwin/window.m
@@ -100,6 +100,7 @@ static void windowCommitShow(uiControl *c)
 	uiWindow *w = (uiWindow *) c;
 
 	[w->window makeKeyAndOrderFront:w->window];
+	[NSApp activateIgnoringOtherApps:YES];
 }
 
 static void windowCommitHide(uiControl *c)


### PR DESCRIPTION
I noticed during my testing that when I run my code from a terminal window on Mac OS X and the terminal window has the focus, the newly drawn window ends up behind my terminal. This patch forces the newly drawn window to the foreground when it's drawn, regardless of which app has the focus.