### PR TITLE
Fix test crash on exit on OS X

### DIFF
--- a/darwin/menu.m
+++ b/darwin/menu.m
@@ -32,8 +32,7 @@ static void mapItemReleaser(void *key, void *value)
 	uiMenuItem *item;
  
 	item = (uiMenuItem *)value;
-	// TODO this crashes for me on OS X El Capitan
-//	[item->item release];
+	[item->item release];
 }
 
 @implementation menuManager
@@ -52,10 +51,10 @@ static void mapItemReleaser(void *key, void *value)
 
 - (void)dealloc
 {
-	uninitMenus();
 	mapWalk(self->items, mapItemReleaser);
 	mapReset(self->items);
 	mapDestroy(self->items);
+    uninitMenus();
 	[super dealloc];
 }
 


### PR DESCRIPTION
This should fix the crash reported in #58. I believe the issue is related to the menus being released, then the menu items being released afterwards, but still referencing the deallocated menu internally, thus the crash.

Oddly enough, I'm using a CMake project to debug with Xcode and when I set it to a bundle target (so it generates a proper .app), it's harder to reproduce, but when I leave it as a console app, it reproduces every time (same as `make test`).