### PR TITLE
Declare 10.9 version in Darwin

### DIFF
--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -13,6 +13,10 @@
 #define toNSString(str) [NSString stringWithUTF8String:(str)]
 #define fromNSString(str) [(str) UTF8String]
 
+#ifndef NSAppKitVersionNumber10_9
+#define NSAppKitVersionNumber10_9 1265
+#endif
+
 // menu.m
 @interface menuManager : NSObject {
 	struct mapTable *items;


### PR DESCRIPTION
NSAppKitVersionNumber10_9 is not declared on Mavericks (10.9) and 10.8, and the compilation fails in these OSes. 

This patch declares the variable with the integer declared in https://developer.apple.com/library/mac/releasenotes/AppKit/RN-AppKit/.