### PR TITLE
Cmake 2.8.12 doesn't understand LANGUAGES keyword on project command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE DEBUG CACHE STRING "" FORCE)
 endif()
 
-project(libui LANGUAGES C CXX)
+project(libui)
 option(BUILD_SHARED_LIBS "Whether to build libui as a shared library or a static library" ON)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/out")


### PR DESCRIPTION
Fortunately we can just use project(libui) since C and CPP are the languages enabled by default.