### PR TITLE
Generate OS X app bundles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 project(libui)
 option(BUILD_SHARED_LIBS "Whether to build libui as a shared library or a static library" ON)
+option(MAKE_MACOS_BUNDLES "Whether to build test and examples as application bundles" OFF)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/out")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/out")
@@ -186,8 +187,11 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 macro(_add_exec _name)
+  if(MAKE_MACOS_BUNDLES)
+    set(_MACOSX_BUNDLE "MACOSX_BUNDLE")
+  endif()
 	add_executable(${_name}
-		WIN32 MACOSX_BUNDLE EXCLUDE_FROM_ALL
+		WIN32 ${_MACOSX_BUNDLE} EXCLUDE_FROM_ALL
 		${ARGN})
 	target_link_libraries(${_name} libui ${_LIBUI_STATIC_RES})
 	_target_link_options_private(${_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ endif()
 
 macro(_add_exec _name)
 	add_executable(${_name}
-		WIN32 EXCLUDE_FROM_ALL
+		WIN32 MACOSX_BUNDLE EXCLUDE_FROM_ALL
 		${ARGN})
 	target_link_libraries(${_name} libui ${_LIBUI_STATIC_RES})
 	_target_link_options_private(${_name}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Project file generators should work, but are untested by me.
 
 On Windows, I use the `Unix Makefiles` generator and GNU make (built using the `build_w32.bat` script included in the source and run in the Visual Studio command line). In this state, if MinGW-w64 (either 32-bit or 64-bit) is not in your `%PATH%`, cmake will use MSVC by default; otherwise, cmake will use with whatever MinGW-w64 is in your path. `set PATH=%PATH%;c:\msys2\mingw(32/64)\bin` should be enough to temporarily change to a MinGW-w64 build for the current command line session only if you installed MinGW-w64 through [MSYS2](https://msys2.github.io/); no need to change global environment variables constantly.
 
+On macOS, you can use `-DMAKE_MACOS_BUNDLES=ON` to generate application bundles for the test and example programs.
+
 ## Installation
 
 #### Arch Linux


### PR DESCRIPTION
This is the standard format for OS X applications. Plus when debugging with Xcode it causes the application to become the frontmost process properly.