### PR TITLE
Fix void* warning

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
 
 	w = newWindow("Main Window", 320, 240, 1);
 	uiWindowOnClosing(w, onClosing, NULL);
-	printf("main window %p\n", w);
+	printf("main window %p\n", (void*)w);
 
 	uiOnShouldQuit(onShouldQuit, w);
 

--- a/test/menus.c
+++ b/test/menus.c
@@ -47,7 +47,7 @@ static void forceOff(uiMenuItem *item, uiWindow *w, void *data)
 
 static void whatWindow(uiMenuItem *item, uiWindow *w, void *data)
 {
-	printf("menu item clicked on window %p\n", w);
+	printf("menu item clicked on window %p\n", (void*)w);
 }
 
 void initMenus(void)


### PR DESCRIPTION
"Format specifies type 'void *' but the argument has type 'uiWindow *' (aka 'struct uiWindow *')"