### PR TITLE
Fix OS X build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,16 @@ endmacro()
 add_subdirectory("common")
 add_subdirectory("${_OSNAME}")
 add_library(${_LIBUINAME} ${_LIBUI_SOURCES})
+# hack to allow building Objective-C files with old versions of cmake
+foreach(SRC ${_LIBUI_SOURCES})
+	if(${SRC} MATCHES .m$)
+		set_source_files_properties(
+			${SRC}
+			PROPERTIES
+			COMPILE_FLAGS
+			"${CMAKE_C_FLAGS}")
+	endif()
+endforeach(SRC)
 target_include_directories(${_LIBUINAME}
 	PUBLIC .
 	PRIVATE ${_LIBUI_INCLUEDIRS})

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 This README is being written.<br>
 [![Build Status](https://travis-ci.org/andlabs/libui.png)](https://travis-ci.org/andlabs/libui)
-*(currently failing because the version of cmake that Travis uses treats Objective-C files as C++; if you know the fix please file a PR)*
 
 ## Announcements
 


### PR DESCRIPTION
This pull request fixes the build by setting all of the files with the ".m" file extension flags to the CMAKE_C_FLAGS variable. Personally I think there is no other simple way as support for Objective-C was officially added to CMake somewhere in 2014 (can't find which version).

Tested with CMake 2.8.12 (see issue #148 why I used 2.8.12) and 3.5.2.