### PR TITLE
Generate documentation using cldoc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,3 +217,21 @@ macro(_add_exec _name)
 endmacro()
 add_subdirectory("test")
 add_subdirectory("examples")
+
+set(API_HEADERS ui.h)
+find_program(CLDOC cldoc)
+if(NOT ${CLDOC} STREQUAL "CLDOC-NOTFOUND")
+  add_custom_target(docs COMMAND
+    ${CLDOC} generate
+    ${CMAKE_C_FLAGS}
+    -I${PROJECT_SOURCE_DIR}
+    --
+    --output "${PROJECT_BINARY_DIR}/docs"
+    ${API_HEADERS}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  set_target_properties(docs PROPERTIES
+    EXCLUDE_FROM_ALL 1
+    EXCLUDE_FROM_DEFAULT_BUILD 1)
+else()
+  message(STATUS "Documentation will not be generated")
+endif()


### PR DESCRIPTION
**Integration with [cldoc](https://jessevdk.github.io/cldoc/) documentation generator**

Once you have installed cldoc & reconfigured cmake: 
```
$ make docs
```

![cldoc-libui1](https://cloud.githubusercontent.com/assets/11763424/16711299/4b67113c-4609-11e6-8101-12028047438f.png)

![cldoc-libui2](https://cloud.githubusercontent.com/assets/11763424/16711300/4e996d28-4609-11e6-949b-b19bb7988304.png)