### PR TITLE
fixed Windows HiDPI support (#184)

### DIFF
--- a/windows/colorbutton.cpp
+++ b/windows/colorbutton.cpp
@@ -61,7 +61,9 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 	ID2D1SolidColorBrush *brush;
 	uiWindowsSizing sizing;
 	int x, y;
+	float dpi_x, dpi_y;
 	HRESULT hr;
+	D2D1_MATRIX_3X2_F dm;
 
 	if (nmhdr->code != NM_CUSTOMDRAW)
 		return FALSE;
@@ -72,6 +74,13 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 	uiWindowsEnsureGetClientRect(b->hwnd, &client);
 	rt = makeHDCRenderTarget(nm->hdc, &client);
 	rt->BeginDraw();
+
+	// scale Direct2D's rendering to be in pixels instead of DIPs
+	rt->GetDpi(&dpi_x, &dpi_y);
+	ZeroMemory(&dm, sizeof (D2D1_MATRIX_3X2_F));
+	dm._11 = 96.f/dpi_x;
+	dm._22 = 96.f/dpi_y;
+	rt->SetTransform(&dm);
 
 	uiWindowsGetSizing(b->hwnd, &sizing);
 	x = 3;		// should be enough

--- a/windows/init.cpp
+++ b/windows/init.cpp
@@ -70,7 +70,7 @@ const char *uiInit(uiInitOptions *o)
 	if ((si.dwFlags & STARTF_USESHOWWINDOW) != 0)
 		nCmdShow = si.wShowWindow;
 
-	// LONGTERM set DPI awareness
+	SetProcessDPIAware();
 
 	hDefaultIcon = LoadIconW(NULL, IDI_APPLICATION);
 	if (hDefaultIcon == NULL)


### PR DESCRIPTION
It seems like this was didn't require much change... perhaps I missed something but I ran the test program and all the controls (after fixing the color selection button) looked fine at a DPI setting of 144dpi (150% scaling) 