### PR TITLE
Add Swift binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Node.js | [libui-node](https://github.com/parro-it/libui-node)
 Python | [pylibui](https://github.com/joaoventura/pylibui)
 Ruby | [libui-ruby](https://github.com/jamescook/libui-ruby)
 Rust | [libui-rs](https://github.com/pcwalton/libui-rs)
+Swift | [libui-swift](https://github.com/sclukey/libui-swift)
 
 ## Screenshots
 


### PR DESCRIPTION
This provides a nice API to libui from Swift (it's OO, just like the Go version and the new D one and most of the other bindings).

Lower level access to libui (the system module package) is provided by [clibui](https://github.com/sclukey/clibui), but most users shouldn't need that if (and since) libui-swift is feature complete. Anyway if anyone does need it they can find it noted in the first line of libui-swift's readme, so there's no need to muddy this list with it.
