### PR TITLE
Resource copying on windows for VC++ 32/64 mingw and msys

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -72,7 +72,7 @@ macro(_handle_static)
 	add_custom_command(
 		TARGET libui POST_BUILD
 		COMMAND
-			${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:libui,BINARY_DIR>/CMakeFiles/libui.dir/windows/resources.rc.* ${_LIBUI_STATIC_RES}
+			${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:libui,BINARY_DIR>/CMakeFiles/libui.dir/windows/resources.rc${CMAKE_RC_OUTPUT_EXTENSION} ${_LIBUI_STATIC_RES}
 		COMMENT "Copying libui.res")
 endmacro()
 


### PR DESCRIPTION
There are still some issues with resource copying on Windows. Not all environments support wildcard expansion. I found a solution with the builtin variable CMAKE_RC_OUTPUT_EXTENSION and tested it with all environments I could easily do:
 - Visual C++ 2015 x64 Native Build Tools DLL and static
 - Visual C++ 2015 x86 Native Build Tools DLL and static
 - MSYS2/mingw64 in bash: static
 - MSYS2/mingw64 in cmd.exe: static
 - JetBrains CLion with mingw64 toolchain

And all configurations are able to compile and start the "controlgallery" example.