### PR TITLE
Fix release build on MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(MSVC)
 	set(_COMMON_CFLAGS
 		/W4 /wd4100
 		/bigobj /nologo
-		/RTC1 /RTCs /RTCu
+		$<$<CONFIG:Debug>:/RTC1 /RTCs /RTCu>
 		/EHsc
 	)
 


### PR DESCRIPTION
The /RTC* flags conflict with all optimizations, therefore they should only be added when building the Debug configuration.