### PR TITLE
Fix MSVC Release build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,15 +71,22 @@ if(MSVC)
 	# TODO /sdl turns C4996 into an ERROR
 	# don't use /analyze; that requires us to write annotations everywhere
 	# TODO undecided flags from qo?
-	# /RTCc is not supplied because it's discouraged as of VS2015; see https://www.reddit.com/r/cpp/comments/46mhne/rtcc_rejects_conformant_code_with_visual_c_2015/d06auq5
 	# /EHsc is to shut the compiler up in some cases
 	# TODO make /EHsc C++-only
 	set(_COMMON_CFLAGS
 		/W4 /wd4100
 		/bigobj /nologo
-		/RTC1 /RTCs /RTCu
 		/EHsc
 	)
+	# Only use RTC on debug builds, because they are expensive and cannot be used
+	# with compiler optimizations. See https://msdn.microsoft.com/en-us/library/8wtf2dfz.aspx
+	# /RTCc is not supplied because it's discouraged as of VS2015; see https://www.reddit.com/r/cpp/comments/46mhne/rtcc_rejects_conformant_code_with_visual_c_2015/d06auq5
+	if(CMAKE_BUILD_TYPE STREQUAL DEBUG)
+		set(_COMMON_CFLAGS
+			"${_COMMON_CFLAGS}"
+			/RTC1 /RTCs /RTCu
+		)
+	endif()
 
 	# note the /MANIFEST:NO (which must be / and uppercase); thanks FraGag (https://github.com/andlabs/libui/issues/93#issuecomment-223183436)
 	# TODO warnings on undefined symbols


### PR DESCRIPTION
Previously, the CMakeLists.txt unconditionally used the /RTC1 /RTCs /RTCu
flags to enable run time checks. However, these flags are not compatible
with optimizations. If one attempted to build libui using
CMAKE_BUILD_TYPE=Release, this would cause the build to fail, since the
MSVC driver uses /02 in Release mode.

This commit only enables those flags in Debug mode, so that they are still
useful for debugging, and Release builds can still be made. Being able to
build in Release mode is useful, because by default other projects
depending on libui may need to build it in Release mode.