### PR TITLE
Better default position for window on macOS

### DIFF
--- a/darwin/window.m
+++ b/darwin/window.m
@@ -367,6 +367,8 @@ static void defaultOnPositionContentSizeChanged(uiWindow *w, void *data)
 	// do nothing
 }
 
+static NSPoint lastTopLeftPoint;
+
 uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 {
 	uiWindow *w;
@@ -380,6 +382,13 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 		backing:NSBackingStoreBuffered
 		defer:YES];
 	[w->window setTitle:toNSString(title)];
+
+	if (NSEqualPoints(lastTopLeftPoint, NSZeroPoint)) {
+		// issue "cascadeTopLeftFromPoint" twice on first time
+		// to have window position in a good place
+		lastTopLeftPoint = [w->window cascadeTopLeftFromPoint:lastTopLeftPoint];
+	}
+	lastTopLeftPoint = [w->window cascadeTopLeftFromPoint:lastTopLeftPoint];
 
 	// do NOT release when closed
 	// we manually do this in uiWindowDestroy() above


### PR DESCRIPTION
Instead default putting windows on bottom-right, this sets default position of windows to a better place, similar to jdk's [nativeSetNSWindowLocationByPlatform](https://github.com/netroby/jdk9-dev/blob/44ab3e51cec57c11f896fe8f5df45a7bf9b4a07f/jdk/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m#L1163-L1186).

There is a question however, should we apply that on [onVisible](https://github.com/netroby/jdk9-dev/blob/44ab3e51cec57c11f896fe8f5df45a7bf9b4a07f/jdk/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java#L551-L561) or the current approach on applying it on newWindow is OK? I guess for the scope of libui the current approach is fine.