### PR TITLE
Put window position on top-right like default Gtk apps

### DIFF
--- a/unix/window.c
+++ b/unix/window.c
@@ -242,6 +242,9 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 	gtk_window_set_title(w->window, title);
 	gtk_window_resize(w->window, width, height);
 
+	// it will put the created window on top-right instead bottom-right
+	gtk_window_set_type_hint(w->window, GDK_WINDOW_TYPE_HINT_MENU);
+
 	w->vboxWidget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 	w->vboxContainer = GTK_CONTAINER(w->vboxWidget);
 	w->vbox = GTK_BOX(w->vboxWidget);


### PR DESCRIPTION
I am not sure why libui doesn't put new window location on a better place like what the example here
https://developer.gnome.org/gtk3/stable/gtk-getting-started.html is doing but I found, probably not very good solution for it so in order to not forget it I am filing it as PR. Feel free to just close it in case you found a better solution thanks.