### PR TITLE
Add uiEntryOnFinished() event to uiEntry

### DIFF
--- a/darwin/entry.m
+++ b/darwin/entry.m
@@ -155,6 +155,11 @@ void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
 	e->onChangedData = data;
 }
 
+void uiEntryOnFinished(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
+{
+	// TODO
+}
+
 int uiEntryReadOnly(uiEntry *e)
 {
 	return [e->textfield isEditable] == NO;

--- a/ui.h
+++ b/ui.h
@@ -154,6 +154,7 @@ typedef struct uiEntry uiEntry;
 _UI_EXTERN char *uiEntryText(uiEntry *e);
 _UI_EXTERN void uiEntrySetText(uiEntry *e, const char *text);
 _UI_EXTERN void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *e, void *data), void *data);
+_UI_EXTERN void uiEntryOnFinished(uiEntry *e, void (*f)(uiEntry *e, void *data), void *data);
 _UI_EXTERN int uiEntryReadOnly(uiEntry *e);
 _UI_EXTERN void uiEntrySetReadOnly(uiEntry *e, int readonly);
 _UI_EXTERN uiEntry *uiNewEntry(void);

--- a/unix/entry.c
+++ b/unix/entry.c
@@ -9,6 +9,8 @@ struct uiEntry {
 	void (*onChanged)(uiEntry *, void *);
 	void *onChangedData;
 	gulong onChangedSignal;
+	void (*onFinished)(uiEntry *, void *);
+	void *onFinishedData;
 };
 
 uiUnixControlAllDefaults(uiEntry)
@@ -16,11 +18,21 @@ uiUnixControlAllDefaults(uiEntry)
 static void onChanged(GtkEditable *editable, gpointer data)
 {
 	uiEntry *e = uiEntry(data);
-
 	(*(e->onChanged))(e, e->onChangedData);
 }
 
 static void defaultOnChanged(uiEntry *e, void *data)
+{
+	// do nothing
+}
+
+static void onFinished(GtkEditable *editable, gpointer data)
+{
+	uiEntry *e = uiEntry(data);
+	(*(e->onFinished))(e, e->onFinishedData);
+}
+
+static void defaultOnFinished(uiEntry *e, void *data)
 {
 	// do nothing
 }
@@ -44,6 +56,13 @@ void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
 	e->onChanged = f;
 	e->onChangedData = data;
 }
+
+void uiEntryOnFinished(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
+{
+	e->onFinished = f;
+	e->onFinishedData = data;
+}
+
 
 int uiEntryReadOnly(uiEntry *e)
 {
@@ -72,6 +91,9 @@ static uiEntry *finishNewEntry(GtkWidget *w, const gchar *signal)
 
 	e->onChangedSignal = g_signal_connect(e->widget, signal, G_CALLBACK(onChanged), e);
 	uiEntryOnChanged(e, defaultOnChanged, NULL);
+
+	g_signal_connect(e->widget, "activate", G_CALLBACK(onFinished), e);
+	uiEntryOnFinished(e, defaultOnFinished, NULL);
 
 	return e;
 }

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -76,6 +76,11 @@ void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
 	e->onChangedData = data;
 }
 
+void uiEntryOnFinished(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
+{
+	// TODO
+}
+
 int uiEntryReadOnly(uiEntry *e)
 {
 	return (getStyle(e->hwnd) & ES_READONLY) != 0;

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -7,19 +7,27 @@ struct uiEntry {
 	void (*onChanged)(uiEntry *, void *);
 	void *onChangedData;
 	BOOL inhibitChanged;
+	void (*onFinished)(uiEntry *, void *);
+	void *onFinishedData;
 };
 
 static BOOL onWM_COMMAND(uiControl *c, HWND hwnd, WORD code, LRESULT *lResult)
 {
 	uiEntry *e = uiEntry(c);
 
-	if (code != EN_CHANGE)
-		return FALSE;
-	if (e->inhibitChanged)
-		return FALSE;
-	(*(e->onChanged))(e, e->onChangedData);
-	*lResult = 0;
-	return TRUE;
+	if (code == EN_CHANGE) {
+    	if (e->inhibitChanged)
+	    	return FALSE;
+    	(*(e->onChanged))(e, e->onChangedData);
+	    *lResult = 0;
+    	return TRUE;
+    }
+	if (code == EN_KILLFOCUS) {
+    	(*(e->onFinished))(e, e->onFinishedData);
+	    *lResult = 0;
+    	return TRUE;
+    }
+    return FALSE;
 }
 
 static void uiEntryDestroy(uiControl *c)
@@ -56,6 +64,11 @@ static void defaultOnChanged(uiEntry *e, void *data)
 	// do nothing
 }
 
+static void defaultOnFinished(uiEntry *e, void *data)
+{
+	// do nothing
+}
+
 char *uiEntryText(uiEntry *e)
 {
 	return uiWindowsWindowText(e->hwnd);
@@ -78,7 +91,8 @@ void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
 
 void uiEntryOnFinished(uiEntry *e, void (*f)(uiEntry *, void *), void *data)
 {
-	// TODO
+	e->onFinished = f;
+	e->onFinishedData = data;
 }
 
 int uiEntryReadOnly(uiEntry *e)
@@ -111,6 +125,7 @@ static uiEntry *finishNewEntry(DWORD style)
 
 	uiWindowsRegisterWM_COMMANDHandler(e->hwnd, onWM_COMMAND, uiControl(e));
 	uiEntryOnChanged(e, defaultOnChanged, NULL);
+	uiEntryOnFinished(e, defaultOnFinished, NULL);
 
 	return e;
 }


### PR DESCRIPTION
This change adds an event to uiEntry, which fires when the editing is 'complete', as opposed to OnChanged(), which fires more-or-less for every keypress.
I settled on the term 'Finished' rather than 'Enter' or 'Submit' or similar.
'Submit' sounded too form-like, and 'Enter' seems to imply the 'enter' key, but there are other conditions where the event might fire (eg tabbing, using search-box icons etc).

There's no specific attempt here to address the dialog-submission issues, but it's something of a moot point right now as libui doesn't support building dialog windows at the moment (right?).
Pretty sure nothing here would interfere with OS-specific dialog behaviour in any major way anyway.

Addresses #1 (and related: andlabs/ui#205)