### PR TITLE
Disabled MSVC (CRT) telemetry on Windows builds.

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND _LIBUI_SOURCES
 	windows/main.cpp
 	windows/menu.cpp
 	windows/multilineentry.cpp
+	windows/notelemetry.cpp
 	windows/opentype.cpp
 	windows/parent.cpp
 	windows/progressbar.cpp

--- a/windows/notelemetry.cpp
+++ b/windows/notelemetry.cpp
@@ -1,4 +1,4 @@
-// This file desables MSVC CRT from calling telemetry functions.
+// This file disables MSVC CRT from calling telemetry functions.
 
 // See: https://www.reddit.com/r/cpp/comments/4ibauu/visual_studio_adding_telemetry_function_calls_to/d2wrf57/
 // See also: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\crt\src\linkopts\notelemetry.cpp
@@ -9,8 +9,10 @@ extern "C"
 {
     void __cdecl __vcrt_initialize_telemetry_provider() { }
     void __cdecl __vcrt_uninitialize_telemetry_provider() { }
+    // These were the two on the reddit posts, which I believe are for VS 2015.
     void __cdecl __telemetry_main_invoke_trigger() { }
     void __cdecl __telemetry_main_return_trigger() { }
+    // These two funcions were in the 'notelemetry.cpp' source included with VS 2017, listed in above comment.
     void __cdecl __telemetry_main_invoke_trigger(HINSTANCE) { }
     void __cdecl __telemetry_main_return_trigger(HINSTANCE) { }
 }

--- a/windows/notelemetry.cpp
+++ b/windows/notelemetry.cpp
@@ -1,0 +1,16 @@
+// This file desables MSVC CRT from calling telemetry functions.
+
+// See: https://www.reddit.com/r/cpp/comments/4ibauu/visual_studio_adding_telemetry_function_calls_to/d2wrf57/
+// See also: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\crt\src\linkopts\notelemetry.cpp
+
+#include <windows.h>
+
+extern "C"
+{
+    void __cdecl __vcrt_initialize_telemetry_provider() { }
+    void __cdecl __vcrt_uninitialize_telemetry_provider() { }
+    void __cdecl __telemetry_main_invoke_trigger() { }
+    void __cdecl __telemetry_main_return_trigger() { }
+    void __cdecl __telemetry_main_invoke_trigger(HINSTANCE) { }
+    void __cdecl __telemetry_main_return_trigger(HINSTANCE) { }
+}


### PR DESCRIPTION
This should solve any issues with Microsoft's telemetry service automatically firing telemetry requests.

Also, I do not understand (nor do I really want to :P) a lot of `cmake`, so I hope I added the reference to `notelemetry.cpp` in the right spot (and I didn't miss anything).

The result builds on Windows 10 Pro 64-Bit, using Visual Studio 2017 (15.5.5).