### PR TITLE
Fix uiprivTimer::f,  it should return an int

### DIFF
--- a/windows/uipriv_windows.hpp
+++ b/windows/uipriv_windows.hpp
@@ -97,7 +97,7 @@ extern void uninitUtilWindow(void);
 // main.cpp
 typedef struct uiprivTimer;
 struct uiprivTimer {
-	void (*f)(void *);
+	int (*f)(void *);
 	void *data;
 };
 extern int registerMessageFilter(void);


### PR DESCRIPTION
On Windows, f is declared as a void returning function:

https://github.com/andlabs/libui/blob/591b9c87721b2e38fe6b2b1c455187375c764fa6/windows/uipriv_windows.hpp#L98-L102

But here it's result is negated as it's returning an int:

https://github.com/andlabs/libui/blob/591b9c87721b2e38fe6b2b1c455187375c764fa6/windows/utilwin.cpp#L40-L46

And here, it's set an int returning function:

https://github.com/andlabs/libui/blob/591b9c87721b2e38fe6b2b1c455187375c764fa6/windows/main.cpp#L132-L142


See also discussion here: https://github.com/andlabs/libui/pull/157