### PR TITLE
Fixes to compile on windows with msys2

### DIFF
--- a/windows/utf16.cpp
+++ b/windows/utf16.cpp
@@ -1,6 +1,13 @@
 // 21 april 2016
 #include "uipriv_windows.hpp"
 
+// sanity check - make sure wchar_t is 16 bits (the assumption on windows)
+// (MinGW-w64 gcc does seem to define a 16bit wchar_t, but you never know. Other windows gcc ports might not)
+#if WCHAR_MAX > 0xFFFF
+  #error wchar_t larger than 16bit
+#endif
+
+
 // see http://stackoverflow.com/a/29556509/3408572
 
 WCHAR *toUTF16(const char *str)

--- a/windows/winapi.hpp
+++ b/windows/winapi.hpp
@@ -23,6 +23,13 @@
 #define _WIN32_IE			0x0700
 #define NTDDI_VERSION		0x06000000
 
+// the msys2 header has an unverified IDWriteTypography definition.
+// Would be good to get it verified and fixed in msys2, but in the meantime,
+// this define lets us compile....
+#if !defined(_MSC_VER)
+#define __MINGW_USE_BROKEN_INTERFACE
+#endif
+
 #include <windows.h>
 
 // Microsoft's resource compiler will segfault if we feed it headers it was not designed to handle


### PR DESCRIPTION
msys2 seems to be unsure of it's IDWriteTypography definition and
disables it by default. This overrides the disabling (The
IDWriteTypography definition looks OK to me, and seems to work
fine).

This commit also adds in a canary to detect compilers that have a non-16bit
wchar_t on windows (eg a gcc focused on porting unix code rather
than compiling windows code).