### PR TITLE
windows: fix build by msys2 toolchain

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -75,7 +75,7 @@ macro(_handle_static)
 	add_custom_command(
 		TARGET libui POST_BUILD
 		COMMAND
-			${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:libui,BINARY_DIR>/CMakeFiles/libui.dir/windows/resources.rc.* ${_LIBUI_STATIC_RES}
+			${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:libui,BINARY_DIR>/CMakeFiles/libui.dir/windows/resources.rc${CMAKE_C_OUTPUT_EXTENSION} ${_LIBUI_STATIC_RES}
 		COMMENT "Copying libui.res")
 endmacro()
 


### PR DESCRIPTION
tested with CMake versions 3.11.0 and 3.1.0
with 3.11.0 - build passed
with 3.1.0 - this part works, but build failed because of empty $<TARGET_PROPERTY:libui,BINARY_DIR>