### PR TITLE
Do no draw uiSlider value on unix systems to match darwin & windows.

### DIFF
--- a/unix/slider.c
+++ b/unix/slider.c
@@ -61,6 +61,9 @@ uiSlider *uiNewSlider(int min, int max)
 	s->range = GTK_RANGE(s->widget);
 	s->scale = GTK_SCALE(s->widget);
 
+	// do not display current value
+	gtk_scale_set_draw_value(s->scale, 0);
+
 	// ensure integers, just to be safe
 	gtk_scale_set_digits(s->scale, 0);
 


### PR DESCRIPTION
As can be seen in the example screenshots provided in the README, the slider on Unix platforms looks somewhat different. It draws the current value above the slider. This commit fixes that - makes all platforms look the same.