### PR TITLE
Fix uiAreaBeginUserWindowResize on macOS

### DIFF
--- a/darwin/winmoveresize.m
+++ b/darwin/winmoveresize.m
@@ -113,14 +113,14 @@ static void minMaxAutoLayoutSizes(NSWindow *w, NSSize *min, NSSize *max)
 	cw = uiprivMkConstraint(contentView, NSLayoutAttributeWidth,
 		NSLayoutRelationEqual,
 		nil, NSLayoutAttributeNotAnAttribute,
-		0, CGFLOAT_MAX,
+		0, 100000,
 		@"window maximum width finding constraint");
 	[cw setPriority:NSLayoutPriorityDragThatCanResizeWindow];
 	[contentView addConstraint:cw];
 	ch = uiprivMkConstraint(contentView, NSLayoutAttributeHeight,
 		NSLayoutRelationEqual,
 		nil, NSLayoutAttributeNotAnAttribute,
-		0, CGFLOAT_MAX,
+		0, 100000,
 		@"window maximum height finding constraint");
 	[ch setPriority:NSLayoutPriorityDragThatCanResizeWindow];
 	[contentView addConstraint:ch];
@@ -206,15 +206,40 @@ static void onResizeDrag(struct onResizeDragParams *p, NSEvent *e)
 
 	// constrain
 	// TODO should we constrain against anything else as well? minMaxAutoLayoutSizes() already gives us nonnegative sizes, but...
-	if (frame.size.width < p->min.width)
+	if (frame.size.width < p->min.width){
+		if(p->edge == uiWindowResizeEdgeLeft ||
+		   p->edge == uiWindowResizeEdgeTopLeft ||
+		   p->edge == uiWindowResizeEdgeBottomLeft) {
+			frame.origin.x += frame.size.width - p->min.width;
+		}
 		frame.size.width = p->min.width;
-	if (frame.size.height < p->min.height)
+	}
+	if (frame.size.height < p->min.height){
+		if(p->edge == uiWindowResizeEdgeBottom ||
+		   p->edge == uiWindowResizeEdgeBottomLeft ||
+		   p->edge == uiWindowResizeEdgeBottomRight) {
+			frame.origin.y += frame.size.height - p->min.height;
+		}
 		frame.size.height = p->min.height;
+	}
+
 	// TODO > or >= ?
-	if (frame.size.width > p->max.width)
+	if (frame.size.width > p->max.width){
+		if(p->edge == uiWindowResizeEdgeLeft ||
+		   p->edge == uiWindowResizeEdgeTopLeft ||
+		   p->edge == uiWindowResizeEdgeBottomLeft) {
+			frame.origin.x -= p->max.width - frame.size.width;
+		}
 		frame.size.width = p->max.width;
-	if (frame.size.height > p->max.height)
+	}
+	if (frame.size.height > p->max.height){
+		if(p->edge == uiWindowResizeEdgeBottom ||
+		   p->edge == uiWindowResizeEdgeBottomLeft ||
+		   p->edge == uiWindowResizeEdgeBottomRight) {
+			frame.origin.y -= p->max.height - frame.size.height;
+		}
 		frame.size.height = p->max.height;
+	}
 
 	[p->w setFrame:frame display:YES];			// and do reflect the new frame immediately
 }


### PR DESCRIPTION
1. `CGFLOAT_MAX` isn't valid value for a constraint (is 100000 is ok?)
2. The position (= origin) of the window changes when resizing on the left or bottom edge.

Fixes #357