### PR TITLE
Add `void *user` into `struct uiControl`

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -80,6 +80,7 @@ struct uiControl {
 	uint32_t Signature;
 	uint32_t OSSignature;
 	uint32_t TypeSignature;
+	void *user;
 	void (*Destroy)(uiControl *);
 	uintptr_t (*Handle)(uiControl *);
 	uiControl *(*Parent)(uiControl *);


### PR DESCRIPTION
This pointer dedicated to user program, libui should not touch it in any way.
If available, user program (or language binder) can avoid many ugly and dirty tricks.
8 bytes for each control is small cost for that flexibility.