### PR TITLE
Add uiEntry method to set width chars

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -164,6 +164,7 @@ _UI_EXTERN void uiEntrySetText(uiEntry *e, const char *text);
 _UI_EXTERN void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *e, void *data), void *data);
 _UI_EXTERN int uiEntryReadOnly(uiEntry *e);
 _UI_EXTERN void uiEntrySetReadOnly(uiEntry *e, int readonly);
+_UI_EXTERN void uiEntrySetWidthChars(uiEntry *e, int nchars);
 _UI_EXTERN uiEntry *uiNewEntry(void);
 _UI_EXTERN uiEntry *uiNewPasswordEntry(void);
 _UI_EXTERN uiEntry *uiNewSearchEntry(void);

--- a/ui_windows.h
+++ b/ui_windows.h
@@ -242,6 +242,7 @@ struct uiWindowsSizing {
 };
 _UI_EXTERN void uiWindowsGetSizing(HWND hwnd, uiWindowsSizing *sizing);
 _UI_EXTERN void uiWindowsSizingDlgUnitsToPixels(uiWindowsSizing *sizing, int *x, int *y);
+_UI_EXTERN void uiWindowsSizingCharsToPixels(uiWindowsSizing *sizing, int *x, int *y, int width_chars);
 _UI_EXTERN void uiWindowsSizingStandardPadding(uiWindowsSizing *sizing, int *x, int *y);
 
 // TODO document

--- a/ui_windows.h
+++ b/ui_windows.h
@@ -242,7 +242,7 @@ struct uiWindowsSizing {
 };
 _UI_EXTERN void uiWindowsGetSizing(HWND hwnd, uiWindowsSizing *sizing);
 _UI_EXTERN void uiWindowsSizingDlgUnitsToPixels(uiWindowsSizing *sizing, int *x, int *y);
-_UI_EXTERN void uiWindowsSizingCharsToPixels(uiWindowsSizing *sizing, int *x, int *y, int width_chars);
+_UI_EXTERN void uiWindowsSizingCharsToPixels(uiWindowsSizing *sizing, int *x, int width_chars);
 _UI_EXTERN void uiWindowsSizingStandardPadding(uiWindowsSizing *sizing, int *x, int *y);
 
 // TODO document

--- a/unix/entry.c
+++ b/unix/entry.c
@@ -95,3 +95,8 @@ uiEntry *uiNewSearchEntry(void)
 {
 	return finishNewEntry(gtk_search_entry_new(), "search-changed");
 }
+
+void uiEntrySetWidthChars(uiEntry *e, int nchars)
+{
+	gtk_entry_set_width_chars(e->entry, nchars);
+}

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -44,14 +44,12 @@ static void uiEntryMinimumSize(uiWindowsControl *c, int *width, int *height)
 	uiWindowsSizing sizing;
 	int x, y;
 
-	if (e->width_chars <= 0) {
-		x = entryWidth;
-		y = entryHeight;
-		uiWindowsGetSizing(e->hwnd, &sizing);
-		uiWindowsSizingDlgUnitsToPixels(&sizing, &x, &y);
-	} else {
-		uiWindowsGetSizing(e->hwnd, &sizing);
-		uiWindowsSizingCharsToPixels(&sizing, &x, &y, e->width_chars);
+	x = entryWidth;
+	y = entryHeight;
+	uiWindowsGetSizing(e->hwnd, &sizing);
+	uiWindowsSizingDlgUnitsToPixels(&sizing, &x, &y);
+	if (e->width_chars > 0) {
+		uiWindowsSizingCharsToPixels(&sizing, &x, e->width_chars);
 	}
 	*width = x;
 	*height = y;

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -7,6 +7,7 @@ struct uiEntry {
 	void (*onChanged)(uiEntry *, void *);
 	void *onChangedData;
 	BOOL inhibitChanged;
+	int width_chars;
 };
 
 static BOOL onWM_COMMAND(uiControl *c, HWND hwnd, WORD code, LRESULT *lResult)
@@ -43,10 +44,15 @@ static void uiEntryMinimumSize(uiWindowsControl *c, int *width, int *height)
 	uiWindowsSizing sizing;
 	int x, y;
 
-	x = entryWidth;
-	y = entryHeight;
-	uiWindowsGetSizing(e->hwnd, &sizing);
-	uiWindowsSizingDlgUnitsToPixels(&sizing, &x, &y);
+	if (e->width_chars <= 0) {
+		x = entryWidth;
+		y = entryHeight;
+		uiWindowsGetSizing(e->hwnd, &sizing);
+		uiWindowsSizingDlgUnitsToPixels(&sizing, &x, &y);
+	} else {
+		uiWindowsGetSizing(e->hwnd, &sizing);
+		uiWindowsSizingCharsToPixels(&sizing, &x, &y, e->width_chars);
+	}
 	*width = x;
 	*height = y;
 }
@@ -107,6 +113,8 @@ static uiEntry *finishNewEntry(DWORD style)
 	uiWindowsRegisterWM_COMMANDHandler(e->hwnd, onWM_COMMAND, uiControl(e));
 	uiEntryOnChanged(e, defaultOnChanged, NULL);
 
+	e->width_chars = 0;
+
 	return e;
 }
 
@@ -131,4 +139,9 @@ uiEntry *uiNewSearchEntry(void)
 	hr = SetWindowTheme(e->hwnd, L"SearchBoxEdit", NULL);
 	// TODO will hr be S_OK if themes are disabled?
 	return e;
+}
+
+void uiEntrySetWidthChars(uiEntry *e, int nchars)
+{
+	e->width_chars = nchars;
 }

--- a/windows/sizing.cpp
+++ b/windows/sizing.cpp
@@ -48,6 +48,12 @@ void uiWindowsSizingDlgUnitsToPixels(uiWindowsSizing *sizing, int *x, int *y)
 		*y = dlgUnitsToY(*y, sizing->BaseY);
 }
 
+void uiWindowsSizingCharsToPixels(uiWindowsSizing *sizing, int *x, int *y, int width_chars)
+{
+	*x = sizing->BaseX * width_chars;
+	*y = sizing->BaseY;
+}
+
 // from https://msdn.microsoft.com/en-us/library/windows/desktop/dn742486.aspx#sizingandspacing and https://msdn.microsoft.com/en-us/library/windows/desktop/bb226818%28v=vs.85%29.aspx
 // this X value is really only for buttons but I don't see a better one :/
 #define winXPadding 4

--- a/windows/sizing.cpp
+++ b/windows/sizing.cpp
@@ -48,10 +48,10 @@ void uiWindowsSizingDlgUnitsToPixels(uiWindowsSizing *sizing, int *x, int *y)
 		*y = dlgUnitsToY(*y, sizing->BaseY);
 }
 
-void uiWindowsSizingCharsToPixels(uiWindowsSizing *sizing, int *x, int *y, int width_chars)
+void uiWindowsSizingCharsToPixels(uiWindowsSizing *sizing, int *x, int width_chars)
 {
-	*x = sizing->BaseX * width_chars;
-	*y = sizing->BaseY;
+	if (x != NULL)
+		*x = sizing->BaseX * width_chars;
 }
 
 // from https://msdn.microsoft.com/en-us/library/windows/desktop/dn742486.aspx#sizingandspacing and https://msdn.microsoft.com/en-us/library/windows/desktop/bb226818%28v=vs.85%29.aspx


### PR DESCRIPTION
Add into ui.h the function

`void uiEntrySetWidthChars(uiEntry *e, int nchars);`

with the same meaning of the gtk function `gtk_entry_set_width_chars()`.

Windows implementation use a new function `void uiWindowsSizingCharsToPixels(uiWindowsSizing *sizing, int *x, int width_chars);` using font metric to convert chars to pixel size. Then the minimum size code call this function to compute width of the entry only if uiEntrySetWidthChars was used.

Mac OS X implementation not done.