### PR TITLE
Keep in memory getSizing information with hMessageFont on windows

### DIFF
--- a/windows/init.cpp
+++ b/windows/init.cpp
@@ -6,6 +6,7 @@ HINSTANCE hInstance;
 int nCmdShow;
 
 HFONT hMessageFont;
+uiWindowsSizing messageFontSizing;
 
 // LONGTERM needed?
 HBRUSH hollowBrush;
@@ -94,6 +95,11 @@ const char *uiInit(uiInitOptions *o)
 	hMessageFont = CreateFontIndirectW(&(ncm.lfMessageFont));
 	if (hMessageFont == NULL)
 		return ieLastErr("loading default messagebox font; this is the default UI font");
+
+	// Initialize to zero to means that the values are unknown.
+	messageFontSizing.BaseX = 0;
+	messageFontSizing.BaseY = 0;
+	messageFontSizing.InternalLeading = 0;
 
 	if (initContainer(hDefaultIcon, hDefaultCursor) == 0)
 		return ieLastErr("initializing uiWindowsMakeContainer() window class");

--- a/windows/sizing.cpp
+++ b/windows/sizing.cpp
@@ -34,7 +34,10 @@ void getSizing(HWND hwnd, uiWindowsSizing *sizing, HFONT font)
 
 void uiWindowsGetSizing(HWND hwnd, uiWindowsSizing *sizing)
 {
-	return getSizing(hwnd, sizing, hMessageFont);
+	if (messageFontSizing.BaseX == 0) {
+		getSizing(hwnd, &messageFontSizing, hMessageFont);
+	}
+	*sizing = messageFontSizing;
 }
 
 #define dlgUnitsToX(dlg, baseX) MulDiv((dlg), (baseX), 4)

--- a/windows/uipriv_windows.hpp
+++ b/windows/uipriv_windows.hpp
@@ -86,6 +86,8 @@ extern void setWindowText(HWND hwnd, WCHAR *wtext);
 extern HINSTANCE hInstance;
 extern int nCmdShow;
 extern HFONT hMessageFont;
+// keep memory of text metric values given in getSizing in sizing.cpp
+extern uiWindowsSizing messageFontSizing;
 extern HBRUSH hollowBrush;
 extern uiInitOptions options;
 


### PR DESCRIPTION
Avoid calling getSizing with hMessageFont over and over, just keep memory of the sizing information the first time the function is called.

The idea is that hMessageFont and their metric does not depend on the specific window's handle.