### PR TITLE
Fix uiImage on mac

### DIFF
--- a/darwin/image.m
+++ b/darwin/image.m
@@ -34,7 +34,7 @@ void uiImageAppend(uiImage *i, void *pixels, int pixelWidth, int pixelHeight, in
 {
 	NSBitmapImageRep *repCalibrated, *repsRGB;
 	uint8_t *swizzled, *bp, *sp;
-	int n;
+	int n, l;
 	unsigned char *pix[1];
 
 	// OS X demands that R and B are in the opposite order from what we expect
@@ -43,13 +43,17 @@ void uiImageAppend(uiImage *i, void *pixels, int pixelWidth, int pixelHeight, in
 	swizzled = (uint8_t *) uiprivAlloc((byteStride * pixelHeight) * sizeof (uint8_t), "uint8_t[]");
 	bp = (uint8_t *) pixels;
 	sp = swizzled;
-	for (n = 0; n < byteStride * pixelHeight; n += 4) {
-		sp[0] = bp[2];
-		sp[1] = bp[1];
-		sp[2] = bp[0];
-		sp[3] = bp[3];
-		sp += 4;
-		bp += 4;
+	for (l = 0; l < pixelHeight; l++){
+		for (n = 0; n < pixelWidth; n++) {
+			sp[0] = bp[2];
+			sp[1] = bp[1];
+			sp[2] = bp[0];
+			sp[3] = bp[3];
+			sp += 4;
+			bp += 4;
+		}
+		// jump over unused bytes at end of line
+		bp += byteStride - pixelWidth * 4;
 	}
 
 	pix[0] = (unsigned char *) swizzled;

--- a/darwin/image.m
+++ b/darwin/image.m
@@ -34,7 +34,7 @@ void uiImageAppend(uiImage *i, void *pixels, int pixelWidth, int pixelHeight, in
 {
 	NSBitmapImageRep *repCalibrated, *repsRGB;
 	uint8_t *swizzled, *bp, *sp;
-	int n, l;
+	int x, y;
 	unsigned char *pix[1];
 
 	// OS X demands that R and B are in the opposite order from what we expect
@@ -43,8 +43,8 @@ void uiImageAppend(uiImage *i, void *pixels, int pixelWidth, int pixelHeight, in
 	swizzled = (uint8_t *) uiprivAlloc((byteStride * pixelHeight) * sizeof (uint8_t), "uint8_t[]");
 	bp = (uint8_t *) pixels;
 	sp = swizzled;
-	for (l = 0; l < pixelHeight; l++){
-		for (n = 0; n < pixelWidth; n++) {
+	for (y = 0; y < pixelHeight; y++){
+		for (x = 0; x < pixelWidth; x++) {
 			sp[0] = bp[2];
 			sp[1] = bp[1];
 			sp[2] = bp[0];

--- a/uitable.h
+++ b/uitable.h
@@ -19,7 +19,7 @@
 // 	  desktop systems at the time of writing (mid-2018)
 // 
 // uiImage is very simple: it only supports non-premultiplied 32-bit
-// ARGB images, and libui does not provide any image file loading
+// RGBA images, and libui does not provide any image file loading
 // or image format conversion utilities on top of that.
 typedef struct uiImage uiImage;
 
@@ -36,8 +36,8 @@ _UI_EXTERN void uiFreeImage(uiImage *i);
 
 // uiImageAppend adds a representation to the uiImage.
 // pixels should point to a byte array of non-premultiplied pixels
-// stored in [R G B A] order (so ((uint8_t *) pixels)[0] is the A of the
-// first pixel and [3] is the B of the first pixel). pixelWidth and
+// stored in [R G B A] order (so ((uint8_t *) pixels)[0] is the R of the
+// first pixel and [3] is the A of the first pixel). pixelWidth and
 // pixelHeight is the size *in pixels* of the image, and pixelStride is
 // the number *of bytes* per row of the pixels array. Therefore,
 // pixels itself must be at least byteStride * pixelHeight bytes long.


### PR DESCRIPTION
- Fix uiImageAppend on macOS (too much memory was allocated and the copying wasn't correct)
 (not sure if the corresponding linux code is correct)

```
=================================================================
==21689==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000109017da2 at pc 0x0001090b7a82 bp 0x7ffee6c0ce50 sp 0x7ffee6c0ce48
READ of size 1 at 0x000109017da2 thread T0
    #0 0x1090b7a81 in uiImageAppend image.m:48
    #1 0x109005635 in appendImageNamed images.c:196
    #2 0x109014ed6 in makePage16 page16.c:110
    #3 0x10900653d in main main.c:162
    #4 0x7fff7e0aa014 in start (libdyld.dylib:x86_64+0x1014)

0x000109017da2 is located 2 bytes to the right of global variable 'dat0' defined in 'libui-table/test/images.c:4:23' (0x1090179a0) of size 1024
SUMMARY: AddressSanitizer: global-buffer-overflow image.m:48 in uiImageAppend
```