### PR TITLE
Custom drawing macOS BackgroundAttribute

### DIFF
--- a/darwin/attrstr.h
+++ b/darwin/attrstr.h
@@ -89,3 +89,5 @@ extern CFAttributedStringRef uiprivAttributedStringToCFAttributedString(uiDrawTe
 - (id)initWithStart:(size_t)s end:(size_t)e r:(double)red g:(double)green b:(double)blue a:(double)alpha;
 - (void)draw:(CGContextRef)c layout:(uiDrawTextLayout *)layout at:(double)x y:(double)y utf8Mapping:(const size_t *)u16tou8;
 @end
+
+CGColorRef mkcolor(double r, double g, double b, double a);

--- a/darwin/attrstr.m
+++ b/darwin/attrstr.m
@@ -271,26 +271,6 @@ static void addFontAttributeToRange(struct foreachParams *p, size_t start, size_
 	}
 }
 
-static CGColorRef mkcolor(double r, double g, double b, double a)
-{
-	CGColorSpaceRef colorspace;
-	CGColorRef color;
-	CGFloat components[4];
-
-	// TODO we should probably just create this once and recycle it throughout program execution...
-	colorspace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
-	if (colorspace == NULL) {
-		// TODO
-	}
-	components[0] = r;
-	components[1] = g;
-	components[2] = b;
-	components[3] = a;
-	color = CGColorCreate(colorspace, components);
-	CFRelease(colorspace);
-	return color;
-}
-
 static void addBackgroundAttribute(struct foreachParams *p, size_t start, size_t end, double r, double g, double b, double a)
 {
 	uiprivDrawTextBackgroundParams *dtb;
@@ -308,6 +288,7 @@ static void addBackgroundAttribute(struct foreachParams *p, size_t start, size_t
 		return;
 	}
 
+	CFAttributedStringSetAttribute(p->mas, CFRangeMake(start, end - start), (CFStringRef)@"FORCE", @"YES");
 	dtb = [[uiprivDrawTextBackgroundParams alloc] initWithStart:start end:end r:r g:g b:b a:a];
 	[p->backgroundParams addObject:dtb];
 	[dtb release];


### PR DESCRIPTION
Completes the text background drawing fallback if `kCTBackgroundColorAttributeName` is not available.

The output is exactly the same as `kCTBackgroundColorAttributeName`, apart from bug #394 so I would make this the default background drawing on High Sierra (and newer - does someone use Mojave?) and keep using `kCTBackgroundColorAttributeName` on older versions because it might be faster(?).