### PR TITLE
Table - support selection access

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -1463,6 +1463,9 @@ _UI_EXTERN void uiTableAppendButtonColumn(uiTable *t,
 _UI_EXTERN void uiTableOnSelectionChanged(uiTable *t, void (*f)(uiTable *t, void *data), void *data);
 
 // uiTableSelection holds an array of row indexes for a table.
+// it's safe to fiddle with the Items data in place (eg a caller
+// might want to sort them - that's ok). But probably best not to
+// change NumItems or try to reallocate Items.
 typedef struct uiTableSelection uiTableSelection;
 struct uiTableSelection
 {

--- a/ui.h
+++ b/ui.h
@@ -1383,6 +1383,9 @@ struct uiTableParams {
 	// If CellValue() for this column for any row returns NULL, that
 	// row will also use the default background color.
 	int RowBackgroundColorModelColumn;
+	// MultiSelect sets selection mode for the table.
+	// 0=single selection, 1=allow multiple rows to be selected
+	int MultiSelect;
 };
 
 // uiTable is a uiControl that shows tabular data, allowing users to

--- a/ui.h
+++ b/ui.h
@@ -1458,6 +1458,29 @@ _UI_EXTERN void uiTableAppendButtonColumn(uiTable *t,
 	int buttonModelColumn,
 	int buttonClickableModelColumn);
 
+// uiTableOnSelectionChanged sets a callback to invoke upon changes
+// in the set of selected items in the table.
+_UI_EXTERN void uiTableOnSelectionChanged(uiTable *t, void (*f)(uiTable *t, void *data), void *data);
+
+// uiTableSelection holds an array of row indexes for a table.
+typedef struct uiTableSelection uiTableSelection;
+struct uiTableSelection
+{
+	int NumItems;
+	int* Items;
+};
+
+// uiTableCurrentSelection returns a uiTableSelection containing
+// an array of all the selected rows in the table.
+// If no rows are selected, a uiTableSelection will still be
+// returned, with NumItems set to 0.
+// The caller is responsible for calling uiFreeTableSelection()
+// when finished with the uiTableSelection.
+_UI_EXTERN uiTableSelection* uiTableCurrentSelection(uiTable* t);
+
+// uiFreeTableSelection frees any memory allocated to a uiTableSelection
+_UI_EXTERN void uiFreeTableSelection(uiTableSelection* sel);
+
 // uiNewTable() creates a new uiTable with the specified parameters.
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 

--- a/unix/table.c
+++ b/unix/table.c
@@ -531,9 +531,8 @@ static void collectSelection( GtkTreeModel *model,
 	struct growableTableSelection* it = (struct growableTableSelection*)data;
 	int depth = gtk_tree_path_get_depth(path);
 	gint* indices = gtk_tree_path_get_indices(path);
-	if (depth < 1) {
+	if (depth < 1)
 		return;
-	}
 
 	// append to collection
 	if (it->sel.NumItems == it->cap) {
@@ -561,9 +560,8 @@ uiTableSelection* uiTableCurrentSelection(uiTable* t)
 void uiFreeTableSelection(uiTableSelection* sel)
 {
 	struct growableTableSelection* g = (struct growableTableSelection*)sel;
-	if (g->sel.Items) {
+	if (g->sel.Items)
 		uiprivFree(g->sel.Items);
-	}
 	uiprivFree(g);
 }
 
@@ -597,9 +595,8 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	sel = gtk_tree_view_get_selection(t->tv);
 	selMode = GTK_SELECTION_SINGLE;
-	if (p->MultiSelect == 1) {
+	if (p->MultiSelect == 1)
 		selMode = GTK_SELECTION_MULTIPLE;
-	}
 	gtk_tree_selection_set_mode(sel, selMode);
 	g_signal_connect(sel, "changed", G_CALLBACK(onChanged), t);
 	uiTableOnSelectionChanged(t, defaultOnSelectionChanged, NULL);


### PR DESCRIPTION
This stuff adds support for:
- an OnSelectionChanged callback
- uiTableCurrentSelection() to read the currently-selected items
- a MultiSelect flag (to let the user select more than one item at a time)

There's also a table example, which I'll keep in a separate branch for now: see https://github.com/bcampbell/libui/tree/table-example

Just unix (Gtk) version implemented so far. I've got my old code for windows and OSX more or less ready too, but I'll hold off until the API is nailed down.
(My older version returned an iterator object instead of `uiTableSelection`. It was fiddlier to use, but there might still be a good argument for more abstract access).
