### PR TITLE
examples/cpp-multithreaded: fixed locks and timeThread terminate conditions

### DIFF
--- a/examples/cpp-multithread/main.cpp
+++ b/examples/cpp-multithread/main.cpp
@@ -12,8 +12,8 @@ using namespace std;
 uiMultilineEntry *e;
 condition_variable cv;
 mutex m;
-unique_lock<mutex> ourlock(m);
 thread *timeThread;
+volatile bool running = true;
 
 void sayTime(void *data)
 {
@@ -25,8 +25,9 @@ void sayTime(void *data)
 
 void threadproc(void)
 {
-	ourlock.lock();
-	while (cv.wait_for(ourlock, chrono::seconds(1)) == cv_status::timeout) {
+	unique_lock<mutex> ourlock(m);
+	while (running) {
+		cv.wait_for(ourlock, chrono::seconds(1));
 		time_t t;
 		char *base;
 		char *s;
@@ -41,6 +42,10 @@ void threadproc(void)
 
 int onClosing(uiWindow *w, void *data)
 {
+	{
+		unique_lock<mutex> l(m);
+		running = false;
+	}
 	cv.notify_all();
 	// C++ throws a hissy fit if you don't do this
 	// we might as well, to ensure no uiQueueMain() gets in after uiQuit()
@@ -81,8 +86,6 @@ int main(void)
 
 	uiBoxAppend(b, uiControl(e), 1);
 
-	// timeThread needs to lock ourlock itself - see http://stackoverflow.com/a/34121629/3408572
-	ourlock.unlock();
 	timeThread = new thread(threadproc);
 
 	uiWindowOnClosing(w, onClosing, NULL);


### PR DESCRIPTION
C++ unique_lock created through constructor with an argument creates already locked lock. The lock is unlocked with destructor.

condition_variable::wait_for returns true when await at least specified timeout false otherwise. There is no guarantee that it returns false when notified, therefore thread exit is done through extra flag 'running'.