### PR TITLE
Avoid reporting false error for common controls initialization

### DIFF
--- a/windows/init.cpp
+++ b/windows/init.cpp
@@ -105,8 +105,12 @@ const char *uiInit(uiInitOptions *o)
 	ZeroMemory(&icc, sizeof (INITCOMMONCONTROLSEX));
 	icc.dwSize = sizeof (INITCOMMONCONTROLSEX);
 	icc.dwICC = wantedICCClasses;
-	if (InitCommonControlsEx(&icc) == 0)
-		return ieLastErr("initializing Common Controls");
+	if (InitCommonControlsEx(&icc) == 0) {
+		DWORD last_err = GetLastError();
+		if (last_err != 0) {
+			return initerr("=" "initializing Common Controls", L"GetLastError() ==", last_err);
+		}
+	}
 
 	hr = CoInitialize(NULL);
 	if (hr != S_OK && hr != S_FALSE)


### PR DESCRIPTION
On my system, using Windows 7 plus Mingw64 I need the fix otherwise the common controls initialization fails but the error code is actually zero.