### PR TITLE
Point to the correct canonical location for Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Perl6 | [perl6-libui](https://github.com/Garland-g/perl6-libui)
 PHP | [ui](https://github.com/krakjoe/ui)
 Python | [pylibui](https://github.com/joaoventura/pylibui), [pylibui-cffi](https://github.com/Yardanico/pylibui-cffi)
 Ruby | [libui-ruby](https://github.com/jamescook/libui-ruby)
-Rust | [libui-rs](https://github.com/pcwalton/libui-rs), [arcturu/libui-rs](https://github.com/arcturu/libui-rs), [LeoTindall/libui-rs](https://github.com/LeoTindall/libui-rs)
+Rust | [pcwalton/libui-rs](https://github.com/pcwalton/libui-rs), [arcturu/libui-rs](https://github.com/arcturu/libui-rs), [rust-native-ui/libui-rs](https://github.com/rust-native-ui/libui-rs)
 Scala | [scalaui](https://github.com/lolgab/scalaui)
 Swift | [libui-swift](https://github.com/sclukey/libui-swift)
 


### PR DESCRIPTION
I changed my name (from LeoTindall) and moved my fork to an organization, so it should be updated in the README.