### PR TITLE
Update Rust bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Perl6 | [perl6-libui](https://github.com/Garland-g/perl6-libui)
 PHP | [ui](https://github.com/krakjoe/ui)
 Python | [pylibui](https://github.com/joaoventura/pylibui), [pylibui-cffi](https://github.com/Yardanico/pylibui-cffi)
 Ruby | [libui-ruby](https://github.com/jamescook/libui-ruby)
-Rust | [pcwalton/libui-rs](https://github.com/pcwalton/libui-rs), [arcturu/libui-rs](https://github.com/arcturu/libui-rs), [rust-native-ui/libui-rs](https://github.com/rust-native-ui/libui-rs)
+Rust | [libui-rs](https://github.com/rust-native-ui/libui-rs)
 Scala | [scalaui](https://github.com/lolgab/scalaui)
 Swift | [libui-swift](https://github.com/sclukey/libui-swift)
 


### PR DESCRIPTION
All the other bindings are either abandoned or forks of `rust-native/libui-rs`.