### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ But libui is not dead; I am working on it whenever I can, and I hope to get it t
 * All platforms:
 	* [Meson](https://mesonbuild.com/) 0.48.0 or newer
 	* Any of Meson's backends; this section assumes you are using [Ninja](https://ninja-build.org/), but there is no reason the other backends shouldn't work.
+	* [vcpkg] If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install libui with CMake integration in a single command: vcpkg install libui
 * Windows: either
 	* Microsoft Visual Studio 2013 or newer (2013 is needed for `va_copy()`) — you can build either a static or a shared library
 	* MinGW-w64 (other flavors of MinGW may not work) — **you can only build a static library**; shared library support will be re-added once the following features come in:


### PR DESCRIPTION
libui is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build libui, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for libui and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.