### PR TITLE
Fix #416, uiTableModelRowInserted on windows adds 2 rows instead of 1.

### DIFF
--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -36,16 +36,16 @@ void uiTableModelRowInserted(uiTableModel *m, int newIndex)
 	item.iItem = newIndex;
 	item.iSubItem = 0;
 	for (auto t : *(m->tables)) {
+		// update selection state
+		if (SendMessageW(t->hwnd, LVM_INSERTITEM, 0, (LPARAM) (&item)) == (LRESULT) (-1))
+			logLastError(L"error calling LVM_INSERTITEM in uiTableModelRowInserted() to update selection state");
+
 		// actually insert the rows
 		if (SendMessageW(t->hwnd, LVM_SETITEMCOUNT, (WPARAM) newCount, LVSICF_NOINVALIDATEALL) == 0)
 			logLastError(L"error calling LVM_SETITEMCOUNT in uiTableModelRowInserted()");
 		// and redraw every row from the new row down to simulate adding it
 		if (SendMessageW(t->hwnd, LVM_REDRAWITEMS, (WPARAM) newIndex, (LPARAM) (newCount - 1)) == FALSE)
 			logLastError(L"error calling LVM_REDRAWITEMS in uiTableModelRowInserted()");
-
-		// update selection state
-		if (SendMessageW(t->hwnd, LVM_INSERTITEM, 0, (LPARAM) (&item)) == (LRESULT) (-1))
-			logLastError(L"error calling LVM_INSERTITEM in uiTableModelRowInserted() to update selection state");
 	}
 }
 


### PR DESCRIPTION
When LVM_INSERTITEM is called after we updated LVM_SETITEMCOUNT, the actual count will be increased by one causing one extra item to appear in the table and loading data from the model.
This extra item is invisible at first because it doesn't get painted but you can click on it to confirm that it is actually there.

To fix the problem we need to call INSERTITEM first and then update the ITEMCOUNT.

Fixes #416
Fixes andlabs/ui#369

cc @bcampbell
r? @andlabs