### PR TITLE
Set column title on OS X 10.9.

### DIFF
--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -32,6 +32,15 @@
 	return nil;			// appease compiler
 }
 
+static void setTitle(uiprivTableColumn *col, NSString *str)
+{
+	if ([col respondsToSelector:@selector(setTitle:)]) {
+		[col setTitle:str];
+	} else {
+		[[col headerCell] setStringValue:str];
+	}
+}
+
 @end
 
 struct textColumnCreateParams {
@@ -599,7 +608,7 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 
 	str = [NSString stringWithUTF8String:name];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -618,7 +627,7 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 
 	str = [NSString stringWithUTF8String:name];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -645,7 +654,7 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 
 	str = [NSString stringWithUTF8String:name];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -665,7 +674,7 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 
 	str = [NSString stringWithUTF8String:name];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -693,7 +702,7 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 
 	str = [NSString stringWithUTF8String:name];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -704,7 +713,7 @@ void uiTableAppendProgressBarColumn(uiTable *t, const char *name, int progressMo
 
 	str = [NSString stringWithUTF8String:name];
 	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:progressModelColumn];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -715,6 +724,6 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 
 	str = [NSString stringWithUTF8String:name];
 	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }


### PR DESCRIPTION
Hello,

The [title property of NSTableColumn](https://developer.apple.com/documentation/appkit/nstablecolumn/1526875-title?language=objc) is only available on macOS 10.10+, so I get the following error on OS X 10.9.5:

    2020-05-12 12:01:59.876 x[40635:303] get 0x0
    2020-05-12 12:01:59.899 x[40635:303] -[uiprivTextImageCheckboxTableColumn setTitle:]: unrecognized selector sent to instance 0x7f9d43e184c0
    2020-05-12 12:01:59.958 x[40635:303] An uncaught exception was raised
    2020-05-12 12:01:59.959 x[40635:303] -[uiprivTextImageCheckboxTableColumn setTitle:]: unrecognized selector sent to instance 0x7f9d43e184c0

However the [headerCell property of NSTableColumn](https://developer.apple.com/documentation/appkit/nstablecolumn/1525137-headercell?language=objc), which inherits from NSCell, supports the [stringValue property](https://developer.apple.com/documentation/appkit/nscell/1530915-stringvalue?language=objc) on all versions.