### PR TITLE
Fix memory leak in uiTable setEditable on unix.

### DIFF
--- a/unix/table.c
+++ b/unix/table.c
@@ -62,6 +62,7 @@ static void setEditable(uiTableModel *m, GtkTreeIter *iter, int modelColumn, Gtk
 	// TODO avoid the need for this
 	path = gtk_tree_model_get_path(GTK_TREE_MODEL(m), iter);
 	row = gtk_tree_path_get_indices(path)[0];
+	gtk_tree_path_free(path);
 	editable = uiprivTableModelCellEditable(m, row, modelColumn) != 0;
 	g_object_set(r, prop, editable, NULL);
 }

--- a/unix/table.c
+++ b/unix/table.c
@@ -257,6 +257,7 @@ static void progressBarColumnDataFunc(GtkTreeViewColumn *c, GtkCellRenderer *r, 
 	// TODO avoid the need for this
 	path = gtk_tree_model_get_path(GTK_TREE_MODEL(m), iter);
 	rc->row = gtk_tree_path_get_indices(path)[0];
+	gtk_tree_path_free(path);
 	rc->col = p->modelColumn;
 	val = (gint *) g_hash_table_lookup(p->t->indeterminatePositions, rc);
 	if (pval == -1) {


### PR DESCRIPTION
The GtkTreePath was not freed correctly.

I found this memory leak with Valgrind on ubuntu 19 after noticing that memory consumption slowly increases in the *test* application.