### PR TITLE
Implement proper uiTableModel stamps for unix.

### DIFF
--- a/unix/table.h
+++ b/unix/table.h
@@ -11,6 +11,7 @@
 typedef struct uiTableModelClass uiTableModelClass;
 struct uiTableModel {
 	GObject parent_instance;
+	gint stamp;
 	uiTableModelHandler *mh;
 };
 struct uiTableModelClass {

--- a/unix/tablemodel.c
+++ b/unix/tablemodel.c
@@ -188,20 +188,15 @@ static gboolean uiTableModel_iter_nth_child(GtkTreeModel *mm, GtkTreeIter *iter,
 {
 	uiTableModel *m = uiTableModel(mm);
 
-	g_return_val_if_fail(iter->stamp == m->stamp, FALSE);
+	if (parent != NULL || n < 0 || n >= uiprivTableModelNumRows(m)) {
+		iter->stamp = 0;
+		return FALSE;
+	}
 
-	if (parent != NULL)
-		goto bad;
-	if (n < 0)
-		goto bad;
-	if (n >= uiprivTableModelNumRows(m))
-		goto bad;
 	iter->stamp = m->stamp;
 	iter->user_data = GINT_TO_POINTER(n);
+
 	return TRUE;
-bad:
-	iter->stamp = 0;
-	return FALSE;
 }
 
 gboolean uiTableModel_iter_parent(GtkTreeModel *mm, GtkTreeIter *iter, GtkTreeIter *child)


### PR DESCRIPTION
Unix:
- Add dynamic iter stamps to uiTableModel - similar to GtkListStore.
- Add proper logging for invalid iter use instead of silently aborting.

The logging actually brought up issue #504. The second commit in this pr fixes that issue.

The dynamic iter stamps are additionally a stepping stone for a sort model - hopefully soon to come.