### PR TITLE
darwin: Fix uiTable checkbox value not calling SetCellValue().

### DIFF
--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -181,6 +181,8 @@ struct textColumnCreateParams {
 			[self->cb setTransparent:NO];
 			uiDarwinSetControlFont(self->cb, NSRegularControlSize);
 			[self->cb setTranslatesAutoresizingMaskIntoConstraints:NO];
+			[self->cb setTarget:self];
+			[self->cb setAction:@selector(uiprivOnCheckboxAction:)];
 			[self addSubview:self->cb];
 
 			if (self->tf != nil) {


### PR DESCRIPTION
This is something that came up while trying things out with the new tester for uiTable suggested in #508:

The SetCellValue() when clicking a checkbox within a uiTable is never called.
The UI happiliy updates suggesting the value has been set - which is not actually the case.

The checkbox not redrawing with the actual check box value from the model is another related issue, see #507.

As a general questing regarding PRs fixing issues: should I open a separate issue every time? Or is the PR fixing the issue enough? I couldn't find anything in CONTRIBUTING.md