### PR TITLE
Add new API functions to get and set the visibility of table headers.

### DIFF
--- a/darwin/table.m
+++ b/darwin/table.m
@@ -14,8 +14,10 @@
 @interface uiprivTableView : NSTableView {
 	uiTable *uiprivT;
 	uiTableModel *uiprivM;
+	NSTableHeaderView *headerViewRef;
 }
 - (id)initWithFrame:(NSRect)r uiprivT:(uiTable *)t uiprivM:(uiTableModel *)m;
+- (void)restoreHeaderView;
 @end
 
 @implementation uiprivTableView
@@ -26,8 +28,14 @@
 	if (self) {
 		self->uiprivT = t;
 		self->uiprivM = m;
+		self->headerViewRef = [self headerView];
 	}
 	return self;
+}
+
+- (void)restoreHeaderView
+{
+	[self setHeaderView:self->headerViewRef];
 }
 
 // TODO is this correct for overflow scrolling?
@@ -168,6 +176,19 @@ static void uiTableDestroy(uiControl *c)
 	[t->tv release];
 	[t->sv release];
 	uiFreeControl(uiControl(t));
+}
+
+int uiTableHeaderVisible(uiTable *t)
+{
+	return [t->tv headerView] != nil;
+}
+
+void uiTableHeaderSetVisible(uiTable *t, int visible)
+{
+	if (visible)
+		[(uiprivTableView*)t->tv restoreHeaderView];
+	else
+		[t->tv setHeaderView:nil];
 }
 
 uiTable *uiNewTable(uiTableParams *p)

--- a/test/page16.c
+++ b/test/page16.c
@@ -98,11 +98,20 @@ static void modelSetCellValue(uiTableModelHandler *mh, uiTableModel *m, int row,
 		checkStates[row] = uiTableValueInt(val);
 }
 
+void headerVisibleToggled(uiCheckbox *c, void *data)
+{
+	uiTable *t = data;
+	uiTableHeaderSetVisible(t, uiCheckboxChecked(c));
+	uiCheckboxSetChecked(c, uiTableHeaderVisible(t));
+}
+
 static uiTableModel *m;
 
 uiBox *makePage16(void)
 {
 	uiBox *page16;
+	uiBox *controls;
+	uiCheckbox *headerVisible;
 	uiTable *t;
 	uiTableParams p;
 	uiTableTextColumnOptionalParams tp;
@@ -119,6 +128,8 @@ uiBox *makePage16(void)
 	memset(checkStates, 0, 15 * sizeof (int));
 
 	page16 = newVerticalBox();
+	controls = newHorizontalBox();
+	uiBoxAppend(page16, uiControl(controls), 0);
 
 	mh.NumColumns = modelNumColumns;
 	mh.ColumnType = modelColumnType;
@@ -151,6 +162,11 @@ uiBox *makePage16(void)
 
 	uiTableAppendProgressBarColumn(t, "Progress Bar",
 		8);
+
+	headerVisible = uiNewCheckbox("Header Visible");
+	uiCheckboxSetChecked(headerVisible, uiTableHeaderVisible(t));
+	uiCheckboxOnToggled(headerVisible, headerVisibleToggled, t);
+	uiBoxAppend(controls, uiControl(headerVisible), 0);
 
 	return page16;
 }

--- a/ui.h
+++ b/ui.h
@@ -1455,6 +1455,13 @@ _UI_EXTERN void uiTableAppendButtonColumn(uiTable *t,
 	int buttonModelColumn,
 	int buttonClickableModelColumn);
 
+// uiTableHeaderVisible() returns whether the table header is visible
+// or not.
+_UI_EXTERN int uiTableHeaderVisible(uiTable *t);
+
+// uiTableHeaderSetVisible() sets the visibility of the table header.
+_UI_EXTERN void uiTableHeaderSetVisible(uiTable *t, int visible);
+
 // uiNewTable() creates a new uiTable with the specified parameters.
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 

--- a/unix/table.c
+++ b/unix/table.c
@@ -477,6 +477,16 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 	g_ptr_array_add(t->columnParams, p);
 }
 
+int uiTableHeaderVisible(uiTable *t)
+{
+	return gtk_tree_view_get_headers_visible(t->tv);
+}
+
+void uiTableHeaderSetVisible(uiTable *t, int visible)
+{
+	gtk_tree_view_set_headers_visible(t->tv, visible);
+}
+
 uiUnixControlAllDefaultsExceptDestroy(uiTable)
 
 static void uiTableDestroy(uiControl *c)

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -479,6 +479,26 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 	p->buttonClickableModelColumn = buttonClickableModelColumn;
 }
 
+int uiTableHeaderVisible(uiTable *t)
+{
+	HWND header = ListView_GetHeader(t->hwnd);
+	if (header) {
+		LONG style = GetWindowLong(header, GWL_STYLE);
+		return !(style & HDS_HIDDEN);
+	}
+	// TODO abort here?
+	return 0;
+}
+
+void uiTableHeaderSetVisible(uiTable *t, int visible)
+{
+	LONG style = GetWindowLong(t->hwnd, GWL_STYLE);
+	if (visible)
+		SetWindowLong(t->hwnd, GWL_STYLE, style & ~LVS_NOCOLUMNHEADER);
+	else
+		SetWindowLong(t->hwnd, GWL_STYLE, style | LVS_NOCOLUMNHEADER);
+}
+
 uiTable *uiNewTable(uiTableParams *p)
 {
 	uiTable *t;


### PR DESCRIPTION
Proposal for two new API additions to un/hide table headers:

```c
int uiTableHeaderVisible(uiTable *t);
void uiTableHeaderSetVisible(uiTable *t, int visible);
```

@nowind is this similar to what you had in mind with your comment in #310?

--

Added API functions:
uiTableHeaderVisible() to determine whether the table header is visible.
uiTableHeaderSetVisible() to set the visibility of the table header.

Implementation provided for unix, darwin, and windows.

Notes: as darwin does not provide an API for hiding or recreating the
table header I opted for saving a reference and restoring that when the
visibility is set back to true. Setting the header to nil to hide it is
the suggested method for hiding the header according to the docs.