### PR TITLE
Add new API functions for table header clicks and sort indicators.

### DIFF
--- a/darwin/table.h
+++ b/darwin/table.h
@@ -16,6 +16,8 @@ struct uiTable {
 	uiprivScrollViewData *d;
 	int backgroundColumn;
 	uiTableModel *m;
+	void (*headerOnClicked)(uiTable *, int, void *);
+	void *headerOnClickedData;
 };
 
 // tablecolumn.m

--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -584,6 +584,7 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -597,8 +598,9 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	else
 		p.textParams = uiprivDefaultTextColumnOptionalParams;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -608,6 +610,7 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -616,8 +619,9 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	p.makeImageView = YES;
 	p.imageModelColumn = imageModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -627,6 +631,7 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -643,8 +648,9 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	p.makeImageView = YES;
 	p.imageModelColumn = imageModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -654,6 +660,7 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -663,8 +670,9 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	p.checkboxModelColumn = checkboxModelColumn;
 	p.checkboxEditableModelColumn = checkboxEditableModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -674,6 +682,7 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -691,8 +700,9 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	p.checkboxModelColumn = checkboxModelColumn;
 	p.checkboxEditableModelColumn = checkboxEditableModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -701,9 +711,11 @@ void uiTableAppendProgressBarColumn(uiTable *t, const char *name, int progressMo
 {
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:progressModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:progressModelColumn];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -712,9 +724,11 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 {
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }

--- a/test/page16.c
+++ b/test/page16.c
@@ -100,6 +100,21 @@ static void modelSetCellValue(uiTableModelHandler *mh, uiTableModel *m, int row,
 
 static uiTableModel *m;
 
+static void headerOnClicked(uiTable *t, int col, void *data)
+{
+	static int prev = 0;
+
+	if (prev != col)
+		uiTableHeaderSetSortIndicator(t, prev, uiSortNone);
+
+	if (uiTableHeaderSortIndicator(t, col) == uiSortAscending)
+		uiTableHeaderSetSortIndicator(t, col, uiSortDescending);
+	else
+		uiTableHeaderSetSortIndicator(t, col, uiSortAscending);
+
+	prev = col;
+}
+
 uiBox *makePage16(void)
 {
 	uiBox *page16;
@@ -151,6 +166,8 @@ uiBox *makePage16(void)
 
 	uiTableAppendProgressBarColumn(t, "Progress Bar",
 		8);
+
+	uiTableHeaderOnClicked(t, headerOnClicked, NULL);
 
 	return page16;
 }

--- a/ui.h
+++ b/ui.h
@@ -1255,6 +1255,12 @@ _UI_EXTERN uiTableValue *uiNewTableValueColor(double r, double g, double b, doub
 // TODO define whether all this, for both uiTableValue and uiAttribute, is undefined behavior or a caught error
 _UI_EXTERN void uiTableValueColor(const uiTableValue *v, double *r, double *g, double *b, double *a);
 
+_UI_ENUM(uiSort) {
+	uiSortNone,
+	uiSortAscending,
+	uiSortDescending
+};
+
 // uiTableModel is an object that provides the data for a uiTable.
 // This data is returned via methods you provide in the
 // uiTableModelHandler struct.

--- a/ui.h
+++ b/ui.h
@@ -1464,6 +1464,22 @@ _UI_EXTERN void uiTableAppendButtonColumn(uiTable *t,
 // uiNewTable() creates a new uiTable with the specified parameters.
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 
+// uiTableHeaderSetSortIndicator() sets the sort indicator of the table
+// header to display an appropriate arrow on the column header
+_UI_EXTERN void uiTableHeaderSetSortIndicator(uiTable *t,
+	int column,
+	uiSort order);
+
+// uiTableHeaderSortIndicator returns the sort indicator of the specified
+// column
+_UI_EXTERN uiSort uiTableHeaderSortIndicator(uiTable *t, int column);
+
+// uiTableHeaderOnClicked() sets a callback function to be called
+// when a table column header is clicked
+_UI_EXTERN void uiTableHeaderOnClicked(uiTable *t,
+	void (*f)(uiTable *table, int column, void *data),
+	void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -40,6 +40,8 @@ struct uiTable {
 	HWND edit;
 	int editedItem;
 	int editedSubitem;
+	void (*headerOnClicked)(uiTable *, int, void *);
+	void *headerOnClickedData;
 };
 extern int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG *pos);
 


### PR DESCRIPTION
Proposal for introducing an enum sort type `uiSort`:
```c
uiSortNone
uiSortAscending
uiSortDescending
```
Two functions for setting table header sort indicators (only visual, no sorting is performed):
```c
uiSort uiTableHeaderSortIndicator(uiTable *t, int column);
void uiTableHeaderSetSortIndicator(uiTable *t, int column, uiSort order);
```
And a setter for a header on clicked callback function:
```c
void uiTableHeaderOnClicked(uiTable *t, void (*f)(uiTable *table, int column, void *data), void *data);
```

Implementations are provided for darwin, unix, and windows.

Notes: The column is the index of the column when it was added to the table. It might be nice to be able to set a numeric identifier, similar to how table columns are handled on darwin. Or possibly even introducing a `uiTableColumn` type and cleaning up the `uiTableAppendColumn` API. This would however break the existing API, so I left it out for the time being. 