### PR TITLE
Add new API functions to get/set table column widths.

### DIFF
--- a/darwin/table.m
+++ b/darwin/table.m
@@ -216,3 +216,16 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	return t;
 }
+
+int uiTableColumnWidth(uiTable *t, int column)
+{
+	NSTableColumn *tc = [t->tv tableColumnWithIdentifier:[@(column) stringValue]];
+	return [tc width];
+}
+
+void uiTableColumnSetWidth(uiTable *t, int column, int width)
+{
+	NSTableColumn *tc = [t->tv tableColumnWithIdentifier:[@(column) stringValue]];
+	[tc setWidth: width];
+}
+

--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -584,6 +584,7 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -597,8 +598,9 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	else
 		p.textParams = uiprivDefaultTextColumnOptionalParams;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -608,6 +610,7 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -616,8 +619,9 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	p.makeImageView = YES;
 	p.imageModelColumn = imageModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -627,6 +631,7 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -643,8 +648,9 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	p.makeImageView = YES;
 	p.imageModelColumn = imageModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -654,6 +660,7 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -663,8 +670,9 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	p.checkboxModelColumn = checkboxModelColumn;
 	p.checkboxEditableModelColumn = checkboxEditableModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -674,6 +682,7 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -691,8 +700,9 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	p.checkboxModelColumn = checkboxModelColumn;
 	p.checkboxEditableModelColumn = checkboxEditableModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -701,9 +711,11 @@ void uiTableAppendProgressBarColumn(uiTable *t, const char *name, int progressMo
 {
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:progressModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:progressModelColumn];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -712,9 +724,11 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 {
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }

--- a/test/page16.c
+++ b/test/page16.c
@@ -98,11 +98,26 @@ static void modelSetCellValue(uiTableModelHandler *mh, uiTableModel *m, int row,
 		checkStates[row] = uiTableValueInt(val);
 }
 
+uiSpinbox *columnID;
+uiSpinbox *columnWidth;
+static void changedColumnID(uiSpinbox *s, void *data)
+{
+	uiTable *t = data;
+	uiSpinboxSetValue(columnWidth, uiTableColumnWidth(t, uiSpinboxValue(columnID)));
+}
+
+static void changedColumnWidth(uiSpinbox *s, void *data)
+{
+	uiTable *t = data;
+	uiTableColumnSetWidth(t, uiSpinboxValue(columnID), uiSpinboxValue(columnWidth));
+}
+
 static uiTableModel *m;
 
 uiBox *makePage16(void)
 {
 	uiBox *page16;
+	uiBox *controls;
 	uiTable *t;
 	uiTableParams p;
 	uiTableTextColumnOptionalParams tp;
@@ -119,6 +134,8 @@ uiBox *makePage16(void)
 	memset(checkStates, 0, 15 * sizeof (int));
 
 	page16 = newVerticalBox();
+	controls = newHorizontalBox();
+	uiBoxAppend(page16, uiControl(controls), 0);
 
 	mh.NumColumns = modelNumColumns;
 	mh.ColumnType = modelColumnType;
@@ -151,6 +168,16 @@ uiBox *makePage16(void)
 
 	uiTableAppendProgressBarColumn(t, "Progress Bar",
 		8);
+
+	uiBoxAppend(controls, uiControl(uiNewLabel("Column")), 0);
+	columnID = uiNewSpinbox(0, INT_MAX);
+	uiBoxAppend(controls, uiControl(columnID), 0);
+	uiBoxAppend(controls, uiControl(uiNewLabel("Width")), 0);
+	columnWidth = uiNewSpinbox(0, INT_MAX);
+	uiBoxAppend(controls, uiControl(columnWidth), 0);
+
+	uiSpinboxOnChanged(columnID, changedColumnID, t);
+	uiSpinboxOnChanged(columnWidth, changedColumnWidth, t);
 
 	return page16;
 }

--- a/ui.h
+++ b/ui.h
@@ -1458,6 +1458,12 @@ _UI_EXTERN void uiTableAppendButtonColumn(uiTable *t,
 // uiNewTable() creates a new uiTable with the specified parameters.
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 
+// uiTableColumnWidth() return current table column width
+_UI_EXTERN int uiTableColumnWidth(uiTable *t, int column);
+
+// uiTableColumnSetWidth() set table column width
+_UI_EXTERN void uiTableColumnSetWidth(uiTable *t, int column, int width);
+
 #ifdef __cplusplus
 }
 #endif

--- a/unix/table.c
+++ b/unix/table.c
@@ -522,3 +522,16 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	return t;
 }
+
+int uiTableColumnWidth(uiTable *t, int column)
+{
+	GtkTreeViewColumn *c = gtk_tree_view_get_column(t->tv, column);
+	return gtk_tree_view_column_get_width(c);
+}
+
+void uiTableColumnSetWidth(uiTable *t, int column, int width)
+{
+	GtkTreeViewColumn *c = gtk_tree_view_get_column(t->tv, column);
+	gtk_tree_view_column_set_fixed_width(c, width);
+}
+

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -520,3 +520,14 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	return t;
 }
+
+int uiTableColumnWidth(uiTable *t, int column)
+{
+	return ListView_GetColumnWidth(t->hwnd, column);
+}
+
+void uiTableColumnSetWidth(uiTable *t, int column, int width)
+{
+	ListView_SetColumnWidth(t->hwnd, column, width);
+}
+


### PR DESCRIPTION
Proposal to add API functions to get and set table column widths:
```c
int uiTableColumnWidth(uiTable *t, int column);
void uiTableColumnSetWidth(uiTable *t, int column, int width);
```
Same as in #513 we need a way to identify columns, so I cherry picked the commit that does column identification by index.

Implementations provided for all platforms (darwin, unix, windows) with a testbed in page16.