### PR TITLE
Fix table row inserted/deleted documentation and windows implementation.

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -1324,11 +1324,13 @@ _UI_EXTERN uiTableModel *uiNewTableModel(uiTableModelHandler *mh);
 // free table models currently associated with a uiTable.
 _UI_EXTERN void uiFreeTableModel(uiTableModel *m);
 
-// uiTableModelRowInserted() tells any uiTable associated with m
-// that a new row has been added to m at index index. You call
-// this function when the number of rows in your model has
-// changed; after calling it, NumRows() should returm the new row
-// count.
+// uiTableModelRowInserted() tell all uiTables associated with
+// the uiTableModel m that a new row has been added to m at
+// index newIndex.
+// You must insert the row data in your model before calling this
+// function.
+// NumRows() must represent the new row count before you call
+// this function.
 _UI_EXTERN void uiTableModelRowInserted(uiTableModel *m, int newIndex);
 
 // uiTableModelRowChanged() tells any uiTable associated with m

--- a/ui.h
+++ b/ui.h
@@ -1339,12 +1339,13 @@ _UI_EXTERN void uiTableModelRowInserted(uiTableModel *m, int newIndex);
 // this if your data changes at some other point.
 _UI_EXTERN void uiTableModelRowChanged(uiTableModel *m, int index);
 
-// uiTableModelRowDeleted() tells any uiTable associated with m
-// that the row at index index has been deleted. You call this
-// function when the number of rows in your model has changed;
-// after calling it, NumRows() should returm the new row
-// count.
-// TODO for this and Inserted: make sure the "after" part is right; clarify if it's after returning or after calling
+// uiTableModelRowDeleted() tells all uiTables associated with
+// the uiTableModel m that the row at index oldIndex has been
+// deleted.
+// You must delete the row from your model before you call this
+// function.
+// NumRows() must represent the new row count before you call
+// this function.
 _UI_EXTERN void uiTableModelRowDeleted(uiTableModel *m, int oldIndex);
 // TODO reordering/moving
 


### PR DESCRIPTION
As I failed to understand the documentation of both `uiTableModelRowInserted()` and `uiTableModelRowDeleted()` on when to insert to/delete from the underlying model and when to in/decrease the `NumRows()` counter - I decided to do some digging.

As it stands the current implementation does not seem to be so sure itself. The windows code is completely broken. The TODOs regarding API clarification and compatability with unix and darwin were never implemented. This patch set fixes all that.

- Clarify the API: we now require rows to be inserted/deleted in the model before calling  `uiTableModelRowInserted()` and `uiTableModelRowDeleted()`
- Clarify the API: we now require the row count in `NumRows()` to reflect the new row count before calling  `uiTableModelRowInserted()` and `uiTableModelRowDeleted()`
- Fix double row insertion on windows (Fixes #416, #369, and closes/supersedes #484) 

Strictly API wise speaking only gtk seems to require data insertion into the model before calling `uiTableModelRowInserted()`.
With this patch set no implementation actually relies on the value in `NumRows()`.
But my reasoning is that both functions are past tense. The operation has already been performed and hence the state of the model should represent that. Otherwise I would consider the function names to be buggy.

Oh and I used the win32 provided macros instead of the SendMessageW((CastARoo*))((FUNCTIONS))