### PR TITLE
Add new API function to set a table row double click callback.

### DIFF
--- a/darwin/table.h
+++ b/darwin/table.h
@@ -16,6 +16,8 @@ struct uiTable {
 	uiprivScrollViewData *d;
 	int backgroundColumn;
 	uiTableModel *m;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 
 // tablecolumn.m

--- a/test/page16.c
+++ b/test/page16.c
@@ -98,6 +98,11 @@ static void modelSetCellValue(uiTableModelHandler *mh, uiTableModel *m, int row,
 		checkStates[row] = uiTableValueInt(val);
 }
 
+static void onRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	printf("Double clicked row %d\n", row);
+}
+
 static uiTableModel *m;
 
 uiBox *makePage16(void)
@@ -151,6 +156,8 @@ uiBox *makePage16(void)
 
 	uiTableAppendProgressBarColumn(t, "Progress Bar",
 		8);
+
+	uiTableOnRowDoubleClicked(t, onRowDoubleClicked, NULL);
 
 	return page16;
 }

--- a/ui.h
+++ b/ui.h
@@ -1455,6 +1455,12 @@ _UI_EXTERN void uiTableAppendButtonColumn(uiTable *t,
 	int buttonModelColumn,
 	int buttonClickableModelColumn);
 
+// uiTableOnRowDoubleClicked sets a callback to be called when the user
+// double clicks a table row.
+_UI_EXTERN void uiTableOnRowDoubleClicked(uiTable *t,
+	void (*f)(uiTable *t, int row, void *data),
+	void *data);
+
 // uiNewTable() creates a new uiTable with the specified parameters.
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -79,6 +79,17 @@ void uiTableModelRowDeleted(uiTableModel *m, int oldIndex)
 	}
 }
 
+static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
+void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowDoubleClicked = f;
+	t->onRowDoubleClickedData = data;
+}
+
 uiTableModelHandler *uiprivTableModelHandler(uiTableModel *m)
 {
 	return m->mh;
@@ -278,6 +289,15 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 		}
 		return TRUE;
 #endif
+	case NM_DBLCLK:
+		{
+			LVHITTESTINFO ht = {};
+			ht.pt = ((NMITEMACTIVATE *)nmhdr)->ptAction;
+			if (ListView_SubItemHitTest(t->hwnd, &ht) == -1)
+				return FALSE;
+			(*(t->onRowDoubleClicked))(t, ht.iItem, t->onRowDoubleClickedData);
+			return TRUE;
+		}
 	case LVN_ITEMCHANGED:
 		{
 			NMLISTVIEW *nm = (NMLISTVIEW *) nmhdr;
@@ -517,6 +537,8 @@ uiTable *uiNewTable(uiTableParams *p)
 	t->indeterminatePositions = new std::map<std::pair<int, int>, LONG>;
 	if (SetWindowSubclass(t->hwnd, tableSubProc, 0, (DWORD_PTR) t) == FALSE)
 		logLastError(L"SetWindowSubclass()");
+
+	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
 
 	return t;
 }

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -40,6 +40,8 @@ struct uiTable {
 	HWND edit;
 	int editedItem;
 	int editedSubitem;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 extern int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG *pos);
 


### PR DESCRIPTION
Proposal to add a new API function to set a callback for when a user double clicks a table row.
```c
void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *t, int row, void *data), void *data);
```

Implementations provided for darwin, unix, and windows. A small sample usage is provided in page16.

Only thing I'm not quite sure about is the naming. Alternatives would be `uiTableRowOnDoubleClicked` or instead of *DoubleClicked* use *Activated* if we should ever want to support single click activation and disable row selection?