### PR TITLE
docs: Fix simple typo, plaform -> platform

### DIFF
--- a/windows/_rc2bin/winapi.hpp
+++ b/windows/_rc2bin/winapi.hpp
@@ -16,7 +16,7 @@
 // get Windows version right; right now Windows Vista
 // unless otherwise stated, all values from Microsoft's sdkddkver.h
 // TODO is all of this necessary? how is NTDDI_VERSION used?
-// TODO plaform update sp2
+// TODO platform update sp2
 #define WINVER			0x0600	/* from Microsoft's winnls.h */
 #define _WIN32_WINNT		0x0600
 #define _WIN32_WINDOWS	0x0600	/* from Microsoft's pdh.h */

--- a/windows/winapi.hpp
+++ b/windows/winapi.hpp
@@ -16,7 +16,7 @@
 // get Windows version right; right now Windows Vista
 // unless otherwise stated, all values from Microsoft's sdkddkver.h
 // TODO is all of this necessary? how is NTDDI_VERSION used?
-// TODO plaform update sp2
+// TODO platform update sp2
 #define WINVER			0x0600	/* from Microsoft's winnls.h */
 #define _WIN32_WINNT		0x0600
 #define _WIN32_WINDOWS	0x0600	/* from Microsoft's pdh.h */


### PR DESCRIPTION
There is a small typo in windows/_rc2bin/winapi.hpp, windows/winapi.hpp.

Should read `platform` rather than `plaform`.

