### PR TITLE
fix crt mutex unlock exception on exit

### DIFF
--- a/examples/cpp-multithread/main.cpp
+++ b/examples/cpp-multithread/main.cpp
@@ -37,6 +37,7 @@ void threadproc(void)
 		strcpy(s, base);
 		uiQueueMain(sayTime, s);
 	}
+	ourlock.unlock();
 }
 
 int onClosing(uiWindow *w, void *data)


### PR DESCRIPTION
If you configure project with visual studio 2015:
meson --buildtype=release --backend=vs2015 --buildtype=debug build
Then you can see there is an exception on exit, then reason is
same, see http://stackoverflow.com/a/34121629/3408572

Signed-off-by: atmgnd <atmgnd@outlook.com>