### PR TITLE
generate and install .pc file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -174,3 +174,8 @@ if libui_mode == 'static'
 endif
 subdir('test')
 subdir('examples')
+
+pkg = import('pkgconfig')
+pkg.generate(
+  libui_libui,
+  description : 'a portable GUI library for C')


### PR DESCRIPTION
resolves #348

In the builddir, this will generate meson-private/ui.pc when 'ninja' or 'meson --wipe' is run.

The contents look like:
```
prefix=/usr/local
libdir=${prefix}/lib
includedir=${prefix}/include

Name: ui
Description: a portable GUI library for C
Version: undefined
Requires.private: gtk+-3.0 >= 3.10.0
Libs: -L${libdir} -lui
Libs.private: -lm -ldl
Cflags: -I${includedir}
```

Note that version is undefined. That will get defined when the version is added as an argument to the project() function in the meson.build.

It will also get installed when 'ninja install' is run.
To test that, from the builddir you can use `DESTDIR=$PWD/install_test ninja install`

The last line you'll see will be something like
```
Installing /home/andy/src/libui/builddir/meson-private/ui.pc to /home/andy/src/libui/builddir/install_test/usr/local/lib/pkgconfig
```

If you want to add a test like that to the appveyer build, you could add an install line like above, then do something like 'cat .... ui.pc' and then test the exit code (0 means the file exists).