### PR TITLE
fix warning: implicit declaration of function ‘strcasecmp’

### DIFF
--- a/unix/text.c
+++ b/unix/text.c
@@ -13,5 +13,5 @@ void uiFreeText(char *t)
 
 int uiprivStricmp(const char *a, const char *b)
 {
-	return strcasecmp(a, b);
+	return g_ascii_strcasecmp(a, b);
 }


### PR DESCRIPTION
On gcc 11.1.0 (Manjaro), I got this warning

```
[58/93] Compiling C object meson-out/libui.so.0.p/unix_text.c.o
../unix/text.c: In function ‘uiprivStricmp’:
../unix/text.c:16:16: warning: implicit declaration of function
‘strcasecmp’; did you mean ‘g_strcasecmp’?
[-Wimplicit-function-declaration]
   16 |         return strcasecmp(a, b);
      |                ^~~~~~~~~~
      |                g_strcasecmp
```

I assume you'd want to use a g_* function here so you don't have to

Apparently g_strcasecmp is deprecated. Some extra info at
https://people.gnome.org/~ryanl/glib-docs/glib-String-Utility-Functions.html#g-strcasecmp